### PR TITLE
ESP8266/FreeRTOS support.

### DIFF
--- a/src/modules/out_esp8266_ws2812b.c
+++ b/src/modules/out_esp8266_ws2812b.c
@@ -1,0 +1,92 @@
+// ESP8266 i2s-based ws2812b output.
+// Stolen from https://github.com/SuperHouse/esp-open-rtos/blob/master/examples/ws2812_i2s/ws2812_i2s_colour_loop.c
+
+// Matrix order and size
+#if !defined(MATRIX_ORDER_PLAIN) && !defined(MATRIX_ORDER_SNAKE)
+#define MATRIX_ORDER_SNAKE // cause that's what i have, it's also the easiest to wire, IMO.
+#endif
+
+#ifndef MATRIX_X
+#error Define MATRIX_X as the matrixes X size.
+#endif
+
+#ifndef MATRIX_Y
+#error Define MATRIX_Y as the matrixes Y size.
+#endif
+
+#define MATRIX_PIXELS (MATRIX_X * MATRIX_Y)
+
+#include <types.h>
+#include <timers.h>
+#include <matrix.h>
+#include "espressif/esp_common.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "esp/uart.h"
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "ws2812_i2s/ws2812_i2s.h"
+
+ws2812_pixel_t pixels[MATRIX_PIXELS];
+
+int init(void) {
+	ws2812_i2s_init(MATRIX_PIXELS, PIXEL_RGB);
+	memset(pixels, 0, sizeof(ws2812_pixel_t) * MATRIX_PIXELS);
+
+	return 0;
+}
+
+
+int getx(void) {
+	return MATRIX_X;
+}
+int gety(void) {
+	return MATRIX_Y;
+}
+
+int ppos(int x, int y) {
+#ifdef MATRIX_ORDER_PLAIN
+	return (x + (y * MATRIX_X));
+#elif defined(MATRIX_ORDER_SNAKE)
+	// Order is like this
+	// 0 1 2
+	// 5 4 3
+	// 6 7 8
+	return (((y % 2) == 0 ? x : (MATRIX_X - 1) - x) + MATRIX_X*y);
+#endif
+}
+
+int set(int x, int y, RGB *color) {
+	// No OOB check, because performance.
+	ws2812_pixel_t* px = pixels[ppos(x, y)];
+	px->red = color->red;
+	px->green = color->green;
+	px->blue = color->blue;
+	return 0;
+}
+
+
+int clear(void) {
+	memset(pixels, 0, sizeof(ws2812_pixel_t) * led_number);
+	return 0;
+}
+
+int render(void) {
+	ws2812_i2s_update(pixels, PIXEL_RGB);
+	return 0;
+}
+
+ulong wait_until(ulong desired_usec) {
+	return wait_until_core(desired_usec);
+}
+
+void wait_until_break(void) {
+	return wait_until_break_core();
+}
+
+int deinit(void) {
+	// No deinit method? Fine by me.
+	return 0;
+}

--- a/src/os/os_freertos.c
+++ b/src/os/os_freertos.c
@@ -45,6 +45,16 @@ void oscore_event_signal(oscore_event ev) {
 void oscore_event_free(oscore_event ev) {
 }
 
+// Time keeping.
+// Since we don't have a RTC, presumably,
+// we'll use the uptime.
+// This aligns with the above.
+ulong oscore_udate(void) {
+	// Ticks * portTICK_RATE_MS gives us ticks in msecs, we need usecs.
+	// Even if we fake it.
+	return xTaskGetTickCount() * 1000 * portTICK_RATE_MS;
+}
+
 // -- mutex
 #define TOMUT(m) (* (SemaphoreHandle_t*) (m))
 oscore_mutex oscore_mutex_new(void) {

--- a/src/os/os_freertos.c
+++ b/src/os/os_freertos.c
@@ -1,0 +1,64 @@
+// os_freertos: FreeRTOS-based stuff.
+// Lots of stubs.
+
+#include "../types.h"
+#include "../oscore.h"
+#include "../main.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "timers.h"
+#include "semphr.h"
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#define STACK_DEPTH 4096
+#define TASK_PRIORITY 10
+
+// Main entry point.
+static void sled_task(void *pvParameters) {
+	sled_main(0, NULL);
+}
+
+void user_main(void) {
+	if(xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED)
+		vTaskStartScheduler();
+
+	xTaskCreate(&sled_task, "sled", STACK_DEPTH, NULL, 10, NULL);
+}
+
+// -- event
+oscore_event oscore_event_new(void) {
+	return NULL;
+}
+
+int oscore_event_wait_until(oscore_event ev, ulong desired_usec) {
+	portTickType waketick = (desired_usec / 1000) / portTICK_RATE_MS;
+	vTaskDelayUntil(&waketick, 0);
+	return 0;
+}
+
+void oscore_event_signal(oscore_event ev) {
+}
+
+void oscore_event_free(oscore_event ev) {
+}
+
+// -- mutex
+#define TOMUT(m) (* (SemaphoreHandle_t*) (m))
+oscore_mutex oscore_mutex_new(void) {
+	return calloc(1, sizeof(SemaphoreHandle_t));
+}
+
+void oscore_mutex_lock(oscore_mutex m) {
+	xSemaphoreTake(TOMUT(m), portMAX_DELAY);
+}
+
+void oscore_mutex_unlock(oscore_mutex m) {
+	xSemaphoreGive(TOMUT(m));
+}
+
+void oscore_mutex_free(oscore_mutex m) {
+	free(m);
+}


### PR DESCRIPTION
This is far from done.

* [ ] Integrate esp-open-rtos in a submakefile, create sledconf example.
    - I've got little clue about how to do that. I've poked the esp-open-rtos issue tracker for help.
* [x] Create an `os_freertos` for FreeRTOS support.
* [x] Create an `out_esp8266_ws2812b` module that uses the i2s peripheral to control ws2812b leds.
    - The esp-open-rtos project has an [example](https://github.com/SuperHouse/esp-open-rtos/blob/master/extras/ws2812_i2s/ws2812_i2s.c), very nice!