### PR TITLE
bgm_pixelflut: select is bad.

### DIFF
--- a/src/modules/bgm_pixelflut.c
+++ b/src/modules/bgm_pixelflut.c
@@ -228,12 +228,12 @@ static int px_buffer_executeline(const char * line, px_buffer_t * client) {
 		} */
 	} else if (fast_str_startswith("SIZE", line)) {
 		char str[64];
-		int len = snprintf(str, 64, "SIZE %d %d", px_mx, px_my);
+		int len = snprintf(str, 64, "SIZE %d %d\n", px_mx, px_my);
 		if (len > 0 && len < 64)
 			net_send(client, str, len);
 	} else if (fast_str_startswith("STATS", line)) {
 		char str[128];
-		int len = snprintf(str, 128, "STATS px:%u conn:%u", px_pixelcount, px_clientcount);
+		int len = snprintf(str, 128, "STATS px:%u conn:%u\n", px_pixelcount, px_clientcount);
 		if (len > 0 && len < 128)
 			net_send(client, str, len);
 	} else if (fast_str_startswith("HELP", line)) {

--- a/src/modules/bgm_pixelflut.c
+++ b/src/modules/bgm_pixelflut.c
@@ -68,6 +68,13 @@ static oscore_task px_task;
 // The maximum, including 0, size of a line.
 #define PX_LINESIZE 0x2000
 
+const static char PX_helpmsg[] =
+	"PX x y: Get color at position (x,y)\n"
+	"PX x y rrggbb(aa): Draw a pixel (alpha ignored)\n"
+	"SIZE: Get canvas size\n"
+	"STATS: Return statistics\n";
+
+
 typedef struct {
 	int socket;
 	size_t linelen;
@@ -237,12 +244,7 @@ static int px_buffer_executeline(const char * line, px_buffer_t * client) {
 		if (len > 0 && len < 128)
 			net_send(client, str, len);
 	} else if (fast_str_startswith("HELP", line)) {
-		const char * help = "\
-PX x y: Get color at position (x,y)\n\
-PX x y rrggbb(aa): Draw a pixel (alpha ignored)\n\
-SIZE: Get canvas size\n\
-STATS: Return statistics\n";
-		net_sendstr(client, help);
+		net_send(client, PX_helpmsg, sizeof(PX_helpmsg));
 	} else {
 		net_sendstr(client, "ERROR: Unknown command\n");
 		return 1;

--- a/src/modules/bgm_pixelflut.c
+++ b/src/modules/bgm_pixelflut.c
@@ -149,6 +149,8 @@ static void poke_main_thread(void) {
 static int px_buffer_executeline(const char * line, px_buffer_t * client) {
 	// In the original version, this was ripped from pixelnuke,
 	//  and it remains that way, but hopefully I've changed it enough.
+	if (!(line[0] && line[1]))
+		return 0;
 	if (line[0] == 'P' && line[1] == 'X' && line[2]) {
 		const char * ptr = line + 3;
 		const char * endptr = ptr;
@@ -265,11 +267,11 @@ static void px_buffer_update(void * buf) {
 	char * line = buffer->line;
 	while (1) {
 		char * ch = strchr(line, '\n');
-		if (ch)
-			*ch = 0;
-		px_buffer_executeline(line, buf);
 		if (!ch)
 			break;
+
+		*ch = 0;
+		px_buffer_executeline(line, buffer);
 		line = ch + 1;
 	}
 	free(buffer);

--- a/src/modules/bgm_pixelflut.c
+++ b/src/modules/bgm_pixelflut.c
@@ -70,7 +70,7 @@ static oscore_task px_task;
 
 const static char PX_helpmsg[] =
 	"PX x y: Get color at position (x,y)\n"
-	"PX x y rrggbb(aa): Draw a pixel (alpha ignored)\n"
+	"PX x y rrggbb(aa): Draw a pixel (optional alpha)\n"
 	"SIZE: Get canvas size\n"
 	"STATS: Return statistics\n";
 
@@ -198,6 +198,7 @@ static int px_buffer_executeline(const char * line, px_buffer_t * client) {
 		}
 
 		RGB pixel;
+		byte alpha = 255;
 		if (endptr - ptr == 6) {
 			// 0x00RRGGBB
 			pixel.red = c >> 16;
@@ -208,6 +209,9 @@ static int px_buffer_executeline(const char * line, px_buffer_t * client) {
 			pixel.red = c >> 24;
 			pixel.green = c >> 16;
 			pixel.blue = c >> 8;
+			alpha = c;
+			if (!alpha)
+				return 0;
 		} else if (endptr - ptr == 2) {
 			// 0x000000Gr
 			pixel.red = c;
@@ -222,6 +226,9 @@ static int px_buffer_executeline(const char * line, px_buffer_t * client) {
 
 		if (!inbounds)
 			return 0;
+
+		if (alpha != 255)
+			pixel = RGBlerp(alpha, px_array[index], pixel);
 
 		matrix_set(x, y, pixel);
 		px_array[index] = pixel;

--- a/src/modules/bgm_pixelflut.c
+++ b/src/modules/bgm_pixelflut.c
@@ -109,8 +109,9 @@ static inline uint32_t fast_strtoul16(const char *str, const char **endptr) {
 // end shamelessly ripped from pixelnuke
 
 static void net_send(px_buffer_t * client, char * str) {
-	send(client->socket, str, strlen(str), MSG_NOSIGNAL);
-	send(client->socket, "\n", 1, MSG_NOSIGNAL);
+	size_t len = strlen(str);
+	str[len] = '\n';
+	send(client->socket, str, len + 1, MSG_NOSIGNAL);
 }
 
 static void net_err(px_buffer_t * client, char * str) {

--- a/src/modules/bgm_pixelflut.c
+++ b/src/modules/bgm_pixelflut.c
@@ -142,7 +142,7 @@ static void poke_main_thread(void) {
 static int px_buffer_executeline(const char * line, px_buffer_t * client) {
 	// In the original version, this was ripped from pixelnuke,
 	//  and it remains that way, but hopefully I've changed it enough.
-	if (line[0] == 'P' && line[1] == 'X') {
+	if (line[0] == 'P' && line[1] == 'X' && line[2]) {
 		const char * ptr = line + 3;
 		const char * endptr = ptr;
 

--- a/src/os/os_3ds.c
+++ b/src/os/os_3ds.c
@@ -83,6 +83,8 @@ int oscore_ncpus(void) {
 	return 1; // For now.
 }
 
+void oscore_task_pin(oscore_task task, int cpu) {}
+
 // -- mutex
 // TODO: fill this in.
 oscore_mutex oscore_mutex_new(void) {

--- a/src/os/os_dummy.c
+++ b/src/os/os_dummy.c
@@ -71,6 +71,8 @@ int oscore_ncpus(void) {
 	return 1;
 }
 
+void oscore_task_pin(oscore_task task, int cpu) {}
+
 // -- mutex
 oscore_mutex oscore_mutex_new(void) {
 	return NULL;

--- a/src/os/os_unix.c
+++ b/src/os/os_unix.c
@@ -138,6 +138,15 @@ int oscore_ncpus(void) {
 	return sysconf(_SC_NPROCESSORS_ONLN);
 }
 
+void oscore_task_pin(oscore_task task, int cpu) {
+#ifdef pthread_setaffinity_np
+	cpu_set_t cpuset;
+	CPU_ZERO(&cpuset);
+	CPU_SET(cpu, &cpuset);
+	pthread_setaffinity_np(*((pthread_t*) task), sizeof(cpu_set_t), &cpuset);
+#endif
+}
+
 // -- mutex
 oscore_mutex oscore_mutex_new(void) {
 	pthread_mutex_t * mutex = malloc(sizeof(pthread_mutex_t));

--- a/src/oscore.h
+++ b/src/oscore.h
@@ -30,6 +30,7 @@ void oscore_task_yield(void);
 void oscore_task_exit(void * status);
 void * oscore_task_join(oscore_task task);
 int oscore_ncpus(void);
+void oscore_task_pin(oscore_task task, int cpu);
 
 #define TPRIO_HIGH 1
 #define TPRIO_NORMAL 0

--- a/src/taskpool.c
+++ b/src/taskpool.c
@@ -102,6 +102,8 @@ taskpool* taskpool_create(const char* pool_name, int workers, int queue_size) {
 
 	// -- Do this last. It's thread creation. --
 
+	int no_cpus = oscore_ncpus();
+
 	// If the oscore has NO thread support, not even faking, we still want basic GFX modules that use taskpool to not break.
 	// So if pool->workers is 0, then we're just pretending.
 	pool->workers = 0;
@@ -110,6 +112,8 @@ taskpool* taskpool_create(const char* pool_name, int workers, int queue_size) {
 			pool->tasks[pool->workers] = oscore_task_create(pool_name, taskpool_function, pool);
 			if (pool->tasks[pool->workers]) {
 				oscore_task_setprio(pool->tasks[pool->workers], TPRIO_LOW);
+				if (no_cpus == workers)
+					oscore_task_pin(pool->tasks[pool->workers], pool->workers);
 				pool->workers++;
 			}
 		}


### PR DESCRIPTION
Steps to ensure pixelflut world domination.

Performance:
- [x] taskpool thread pinning
- [x] keep a good fdset for select
- [x] add epoll variant
- [ ] add kqueue variant

Features:
- [x] alpha blending

Bugs:
- [x] Doesn't properly exit. Causes CI failure. Mutex/exit FD related?

right now, the pixelflut server works well for big packets on a single client.
but everything else is really limiting concurrency because of that select.

should fix #49.