### PR TITLE
Run CI on both Ubuntu 16.04 and 18.04, upgrade macOS to 10.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,12 @@ pr:
 
 strategy:
   matrix:
-    linux:
+    ubuntu-1604:
       imageName: 'ubuntu-16.04'
+    ubuntu-1804:
+      imageName: 'ubuntu-18.04'
     mac:
-      imageName: 'macos-10.13'
+      imageName: 'macos-10.14'
 
 pool:
   vmImage: $(imageName)


### PR DESCRIPTION
macOS 10.13 will be removed on February 3 in Azure Pipelines.

Ubuntu 18.04 should just work, and if it does not, we have new issues to fix :)