### PR TITLE
sparkburn: When threshold reaches 0 make sure to not be interesting.

### DIFF
--- a/src/modules/gfx_sparkburn.c
+++ b/src/modules/gfx_sparkburn.c
@@ -63,6 +63,7 @@ void reset(int _modno) {
 static void calc() {
     interesting = 0;
     if (threshold) threshold--;
+    else return;
 
     for (int i=0; i<mx; i++) {
         for (int j=0; j<my; j++) {


### PR DESCRIPTION
It is sometimes possible to reach a state where threshold reaches 0.
When that happens sparkburn will keep trying to multiply 0 pixel values
with 1.1 and indefinitely try to reach 255... such a situation will
result in a black display forever.