### PR TITLE
Add nix-build compatible default.nix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ sled.wasm.map
 # CLion
 .idea/
 /compile_commands.json
+
+# nix default result symlink (from nix-build)
+/result

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,32 @@
 with import <nixpkgs> {};
 stdenv.mkDerivation {
+  src = ./.;
   name = "sled";
-  buildInputs = [ gnumake SDL2 ];
+  buildInputs = [ SDL2 ncurses ];
+  enableParallelBuilding = true;
+
+  configurePhase = ''
+      cat >sledconf <<EOF
+      PROJECT := sled
+      DEBUG := 0
+      STATIC := 0
+      PLATFORM := unix
+      DEFAULT_OUTMOD := sdl2
+      DEFAULT_MODULEDIR := "$out/libexec/sled"
+      MODULES := out_\$(DEFAULT_OUTMOD)
+      MODULES += \$(BGMMODS_DEFAULT)
+      MODULES += \$(FLTMODS_DEFAULT)
+      MODULES += \$(GFXMODS_DEFAULT)
+      MATRIX_X := 64
+      MATRIX_Y := 64
+      SDL_SCALE_FACTOR := 4
+      EOF
+    '';
+
+  installPhase = ''
+      mkdir -p $out/bin
+      install -m755 ./sled $out/bin/sled
+      mkdir -p $out/libexec/sled
+      install -m755 ./modules/* $out/libexec/sled
+    '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+with import <nixpkgs> {};
+pkgs.mkShell {
+  buildInputs = [ SDL2 ncurses ];
+}


### PR DESCRIPTION
This allows doing a `nix-build` and getting some mostly-default build of
sled (apart from making the module path point to the store path).

The existing default.nix for `nix-shell` use has also been dusted off
and renamed to `shell.nix`. Things should continue to work as they did
for interactive development.