### PR TITLE
ci: yeet ubuntu 16.04, add modern OSes (let's see what breaks)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [pull_request_target, push]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, macos-10.15]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Github actions hasn't been offering ubuntu 16.04 since September 20, 2021 so let's remove it.

Also, add some more OS versions to test on